### PR TITLE
Added options to set / adjust the projects name in WakaTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ So this Add-On can try to "guess" the projects name from the current blend-filen
 To fine-tune the project's name, there are some options available under *Preferences -> Add-ons -> WakaTime*.<br/>
 (This is also the place where to enable the add-on.)
 
-![Configuration](https://i.imgur.com/Sw8F9JN.png)
+![Configuration](https://i.imgur.com/Wf6ZqPX.png)
 
 The first check-box decides, whether to **always** use the guessed name from this AddOn, effectively overwriting WakaTimes discovered name (i.e. the git-repo).
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ If for some reason you wish to change the key, press Space to summon the floatin
 ![Setup API Key](http://i.imgur.com/if3PLTC.png)
 
 When setup is finished, the plugin should start sending the time you've spent on the currently loaded .blend file automatically in the background. **Note**, that unless you save a newly created file no stats are gathered, because Wakatime needs a filepath.
+
+### Configuration
+The Add-On tries to "guess" the projects name from the current blend-filename.
+
+If there are **trailing** numbers, underscores or dots, those too will be removed (e.g. *"bridge_destruction_01.blend"* will become the project *"bridge_destruction"*).
+
+To set which characters to remove, the user can configure the list under *Preferences*.
+Go to *Add-ons*, search for "WakaTime". There is a text-field that contains the list of characters to remove (if they are trailing the projects name).
+
+#### Examples
+1. To prevent any change of the projects-name, remove all the characters from the text-field and press enter.
+2. To only remove numbers, enter "1234567890" in the text-field and press enter.
+3. To remove numbers, underscores and dots, enter "1234567890.\_" and press enter.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To fine-tune the project's name, there are some options available under *Prefere
 
 The first check-box decides, on what to base the WakaTime-project-name:
 * if not checked: use the filename (without the *.blend*-extensions), or
-* if checked: use the parent's directory-name.
+* if checked: use the directory-name (of the blend-file).
 
 With the project-name extracted, further processing takes place:
 1. If there are specific (default: numbers, underscores and dots) **trailing** characters, those will be removed too.
@@ -35,10 +35,10 @@ With the project-name extracted, further processing takes place:
 3. Optional: add a postfix to the project's title.
 
 #### Examples
-1. To prevent any adjusting of the projects-name, remove all the characters from the text-field and press enter. Also remove any text from the pre- and postfix-strings.
-2. To give the project-name a ".blend"-extension, add ".blend" in the postfix-text-field.
-3. To only remove trailing numbers (e.g. versions), enter "1234567890" in the trailing character-text-field and press enter.
-4. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter. (This is the default.)
-5. To turn "captain_afterburner.blend" into the project-name "\[blender\] captain_afterburner", set the prefix to "\[blender\] ", the postfix to "" (nothing).
-6. To turn "captain_afterburner_05.blend" into the project-name "\[blender\] captain_afterburner", apply steps #4 and #5 together.
-7. If you want to use the "parent" directory's name, check "Use folder-name as project-name". All steps from #2 to #6 can still be used to adjust the name.
+1. To give the project-name a ".blend"-extension, add ".blend" in the postfix-text-field.
+2. To only remove trailing numbers (e.g. versions), enter "1234567890" in the trailing character-text-field and press enter.
+3. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter. (This is the default.)
+4. To turn "captain_afterburner.blend" into the project-name "\[blender\] captain_afterburner", set the prefix to "\[blender\] ", the postfix to "" (nothing).
+5. To turn "captain_afterburner_05.blend" into the project-name "\[blender\] captain_afterburner", apply steps #3 and #4 together.
+6. If you want to use the directory's name, check "Use folder-name as project-name". All steps from #1 to #5 can still be used to adjust the name.
+7. To prevent any adjusting of the projects-name, remove all the characters from all three text-fields and press enter.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ If there are **trailing** numbers, underscores or dots, those too will be remove
 To set which characters to remove, the user can configure the list under *Preferences*.
 Go to *Add-ons*, search for "WakaTime". There is a text-field that contains the list of characters to remove (if they are trailing the projects name).
 
+Additionally the user can set a pre- and postfix to apply to the project's name after the above mentioned cleanup.
+
 #### Examples
-1. To prevent any change of the projects-name, remove all the characters from the text-field and press enter.
-2. To only remove numbers, enter "1234567890" in the text-field and press enter.
-3. To remove numbers, underscores and dots, enter "1234567890.\_" and press enter.
+1. To prevent any adjusting of the projects-name, remove all the characters from the text-field and press enter. Also remove any text from the pre- and postfix-strings.
+2. To have the projects name have a ".blend"-extension, add ".blend" in the postfix-text-field.
+3. To only remove numbers, enter "1234567890" in the trailing character-text-field and press enter.
+4. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter.
+5. To turn "captain_afterburner.blend" into the project-name "\[blender\] captain_afterburner", set the prefix to "\[blender\] ", the postfix to "" (nothing).
+6. To turn "captain_afterburner_05.blend" into the project-name "\[blender\] captain_afterburner", apply steps #4 and #5 together.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When setup is finished, the plugin should start sending the time you've spent on
 WakaTime will try to detect the projects name, e.g. from the git-repo.
 If one does not work with git, the project's name would be "Unknown Project" within WakaTime.
 <br/>
-So this Add-On can try to "guess" the projects name from the current blend-filename or from the project-folder.
+So this Add-On can try to "guess" the project name from the current blend-filename or from the project-folder.
 
 To fine-tune the project's name, there are some options available under *Preferences -> Add-ons -> WakaTime*.<br/>
 (This is also the place where to enable the add-on.)

--- a/README.md
+++ b/README.md
@@ -18,19 +18,23 @@ If for some reason you wish to change the key, press Space to summon the floatin
 When setup is finished, the plugin should start sending the time you've spent on the currently loaded .blend file automatically in the background. **Note**, that unless you save a newly created file no stats are gathered, because Wakatime needs a filepath.
 
 ### Configuration
-The Add-On tries to "guess" the projects name from the current blend-filename.
+The Add-On tries to "guess" the projects name from the current blend-filename or from the projects folder.
 
-If there are **trailing** numbers, underscores or dots, those too will be removed (e.g. *"bridge_destruction_01.blend"* will become the project *"bridge_destruction"*).
+To fine-tune the project's name, there some options are available under *Preferences -> Add-ons -> WakaTime*.<br/>
+(This is also the place where to enable the add-on.)
 
-To set which characters to remove, the user can configure the list under *Preferences*.
-Go to *Add-ons*, search for "WakaTime". There is a text-field that contains the list of characters to remove (if they are trailing the projects name).
+The first option decides, whether to use the directory-name for the project's name or the the filename (without the *.blend*-extensions) in WakaTime. 
 
-Additionally the user can set a pre- and postfix to apply to the project's name after the above mentioned cleanup.
+With the project-name extracted, further processing takes place:
+1. If there are specific (default: numbers, underscores and dots) **trailing** characters, those will be removed too.
+2. Optional: add a prefix to the project's title.
+3. Optional: add a postfix to the project's title.
 
 #### Examples
 1. To prevent any adjusting of the projects-name, remove all the characters from the text-field and press enter. Also remove any text from the pre- and postfix-strings.
 2. To have the projects name have a ".blend"-extension, add ".blend" in the postfix-text-field.
-3. To only remove numbers, enter "1234567890" in the trailing character-text-field and press enter.
-4. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter.
+3. To only remove trailing numbers (e.g. versions), enter "1234567890" in the trailing character-text-field and press enter.
+4. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter. (This is the default.)
 5. To turn "captain_afterburner.blend" into the project-name "\[blender\] captain_afterburner", set the prefix to "\[blender\] ", the postfix to "" (nothing).
 6. To turn "captain_afterburner_05.blend" into the project-name "\[blender\] captain_afterburner", apply steps #4 and #5 together.
+7. If you want to use the "parent" directory's name, check "Use folder-name as project-name". All steps from #2 to #6 can still be used to adjust the name.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The Add-On tries to "guess" the projects name from the current blend-filename or
 To fine-tune the project's name, there are some options available under *Preferences -> Add-ons -> WakaTime*.<br/>
 (This is also the place where to enable the add-on.)
 
-![Configuration](https://imgur.com/a/UaV54KG)
+![Configuration](https://i.imgur.com/22zIvWe.png)
 
 The first check-box decides, on what to base the WakaTime-project-name:
 * if not checked: use the filename (without the *.blend*-extensions), or
-* if checked: use the (parent) directory-name.
+* if checked: use the parent's directory-name.
 
 With the project-name extracted, further processing takes place:
 1. If there are specific (default: numbers, underscores and dots) **trailing** characters, those will be removed too.
@@ -36,7 +36,7 @@ With the project-name extracted, further processing takes place:
 
 #### Examples
 1. To prevent any adjusting of the projects-name, remove all the characters from the text-field and press enter. Also remove any text from the pre- and postfix-strings.
-2. To have the projects name have a ".blend"-extension, add ".blend" in the postfix-text-field.
+2. To give the project-name a ".blend"-extension, add ".blend" in the postfix-text-field.
 3. To only remove trailing numbers (e.g. versions), enter "1234567890" in the trailing character-text-field and press enter.
 4. To remove numbers, underscores and dots, enter "1234567890.\_" in the trailing character-text-field and press enter. (This is the default.)
 5. To turn "captain_afterburner.blend" into the project-name "\[blender\] captain_afterburner", set the prefix to "\[blender\] ", the postfix to "" (nothing).

--- a/README.md
+++ b/README.md
@@ -18,14 +18,19 @@ If for some reason you wish to change the key, press Space to summon the floatin
 When setup is finished, the plugin should start sending the time you've spent on the currently loaded .blend file automatically in the background. **Note**, that unless you save a newly created file no stats are gathered, because Wakatime needs a filepath.
 
 ### Configuration
-The Add-On tries to "guess" the projects name from the current blend-filename or from the project-folder.
+WakaTime will try to detect the projects name, e.g. from the git-repo.
+If one does not work with git, the project's name would be "Unknown Project" within WakaTime.
+<br/>
+So this Add-On can try to "guess" the projects name from the current blend-filename or from the project-folder.
 
 To fine-tune the project's name, there are some options available under *Preferences -> Add-ons -> WakaTime*.<br/>
 (This is also the place where to enable the add-on.)
 
-![Configuration](https://i.imgur.com/22zIvWe.png)
+![Configuration](https://i.imgur.com/Sw8F9JN.png)
 
-The first check-box decides, on what to base the WakaTime-project-name:
+The first check-box decides, whether to **always** use the guessed name from this AddOn, effectively overwriting WakaTimes discovered name (i.e. the git-repo).
+
+The next check-box decides, on what to base the WakaTime-project-name:
 * if not checked: use the filename (without the *.blend*-extensions), or
 * if checked: use the directory-name (of the blend-file).
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ If for some reason you wish to change the key, press Space to summon the floatin
 When setup is finished, the plugin should start sending the time you've spent on the currently loaded .blend file automatically in the background. **Note**, that unless you save a newly created file no stats are gathered, because Wakatime needs a filepath.
 
 ### Configuration
-The Add-On tries to "guess" the projects name from the current blend-filename or from the projects folder.
+The Add-On tries to "guess" the projects name from the current blend-filename or from the project-folder.
 
-To fine-tune the project's name, there some options are available under *Preferences -> Add-ons -> WakaTime*.<br/>
+To fine-tune the project's name, there are some options available under *Preferences -> Add-ons -> WakaTime*.<br/>
 (This is also the place where to enable the add-on.)
 
-The first option decides, whether to use the directory-name for the project's name or the the filename (without the *.blend*-extensions) in WakaTime. 
+![Configuration](https://imgur.com/a/UaV54KG)
+
+The first check-box decides, on what to base the WakaTime-project-name:
+* if not checked: use the filename (without the *.blend*-extensions), or
+* if checked: use the (parent) directory-name.
 
 With the project-name extracted, further processing takes place:
 1. If there are specific (default: numbers, underscores and dots) **trailing** characters, those will be removed too.

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -121,7 +121,7 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     use_project_folder: BoolProperty(
         name = "Use folder-name as project-name",
         default = _default_use_project_folder,
-        description="Will use the name of the parent-folder as the project-name.\n\nExample: if selected, filename 'birthday_project/test_01.blend' will result in project-name 'birthday_project'\n\nHint: if not activated, the blender-filename without the blend-extension is used.\n\nDefault: " + str(bool(_default_use_project_folder)))
+        description="Will use the name of the folder/directory-name as the project-name.\n\nExample: if selected, filename 'birthday_project/test_01.blend' will result in project-name 'birthday_project'\n\nHint: if not activated, the blender-filename without the blend-extension is used.\n\nDefault: " + str(bool(_default_use_project_folder)))
     truncate_trail: StringProperty(
         name = "Cut trailing characters",
         default = _default_chars,
@@ -315,7 +315,7 @@ def handle_activity(is_write=False):
         log(DEBUG, "truncate trailing chars from settings: {}", truncate_chars)
         # project-folder or blend-filename?
         if blender_settings.use_project_folder:
-            _projectname=os.path.basename(os.path.dirname(_filename)) # grab the name of the parent-directory
+            _projectname=os.path.basename(os.path.dirname(_filename)) # grab the name of the directory
         else:
             _projectname = os.path.splitext(_filename)[0] # cut away the (.blend) extension
             _projectname = path_leaf(_projectname) # remove (the full) path from the filename

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -113,15 +113,9 @@ class API_Key_Dialog(bpy.types.Operator):
 # Addon prefs
 class WakaTimePreferences(bpy.types.AddonPreferences):
     bl_idname = __name__
-    _def_chars="<empty>"
-    _def_prefix="<empty>"
-    _def_postfix="<empty>"
-    if len(_default_chars) > 0:
-        _def_chars=_default_chars
-    if len(_default_prefix) > 0:
-        _def_prefix=_default_prefix
-    if len(_default_postfix) > 0:
-        _def_postfix=_default_postfix
+    _def_chars = _default_chars if _default_chars else "<empty>"
+    _def_prefix = _default_prefix if _default_prefix else "<empty>"
+    _def_postfix = _default_postfix if _default_postfix else "<empty>"
     always_overwrite_name: BoolProperty(
         name = "Overwrite project-discovery with the name from below",
         default = _default_always_overwrite_projectname,

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -125,7 +125,7 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     always_overwrite_name: BoolProperty(
         name = "Overwrite project-discovery with the name from below",
         default = _default_always_overwrite_projectname,
-        description="WakaTime will guess the project-name (e.g. from the git-repo). Checking this box will overwrite this auto-discovered name (with the name according to the rules below).\n\nHint: when not working with git, the project's name will always be set according to the rules below.\n\nDefault: " + str(bool(_default_always_overwrite_projectname)))
+        description = "WakaTime will guess the project-name (e.g. from the git-repo). Checking this box will overwrite this auto-discovered name (with the name according to the rules below).\n\nHint: when not working with git, the project's name will always be set according to the rules below.\n\nDefault: {bool(_default_always_overwrite_projectname)}")
     use_project_folder: BoolProperty(
         name = "Use folder-name as project-name",
         default = _default_use_project_folder,

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -37,11 +37,6 @@ _heartbeats = Queue()
 _hb_processor = None
 _last_hb = None
 _filename = ''
-_default_always_overwrite_projectname=0
-_default_chars='1234567890._'
-_default_prefix=''
-_default_postfix=''
-_default_use_project_folder=0
 
 REGISTERED = False
 SHOW_KEY_DIALOG = False
@@ -111,6 +106,11 @@ class API_Key_Dialog(bpy.types.Operator):
 
 # Addon prefs
 class WakaTimePreferences(bpy.types.AddonPreferences):
+    _default_always_overwrite_projectname = 0
+    _default_chars = '1234567890._'
+    _default_prefix = ''
+    _default_postfix = ''
+    _default_use_project_folder = 0
     bl_idname = __name__
     _def_chars = _default_chars if _default_chars else "<empty>"
     _def_prefix = _default_prefix if _default_prefix else "<empty>"

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -36,6 +36,8 @@ _hb_processor = None
 _last_hb = None
 _filename = ''
 _default_chars='1234567890._'
+_default_prefix=''
+_default_postfix=''
 
 REGISTERED = False
 SHOW_KEY_DIALOG = False
@@ -109,12 +111,22 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     truncate_trail: StringProperty(
         name = "Cut trailing characters",
         default = _default_chars,
-        description="When guessing the projects name, the filename without the ('blend') extension is used.\nAdditionally any trailing characters listed here are removed too.\n\nExample: filename 'birthday_01_test_01.blend' will result in project-name 'birthday_01_test'\n\nDefault: '" + _default_chars + "'")
+        description="When guessing the projects name, the filename without the blend-extension and without these trailing characters is used.\n\nExample: filename 'birthday_01_test_01.blend' will result in project-name 'birthday_01_test'\n\nDefault: " + _default_chars)
+    project_prefix: StringProperty(
+        name = "project-name prefix",
+        default = _default_prefix,
+        description="This prefix will be attached in front of all project-names.\n\nDefault: " + _default_prefix)
+    project_postfix: StringProperty(
+        name = "project-name postfix",
+        default = _default_postfix,
+        description="This postfix will be attached at the end of all project-names, after the trailing characters were removed.\n\nDefault: " + _default_postfix)
 
     def draw(self, context):
         layout = self.layout
         col = layout.column()
         col.prop(self, "truncate_trail")
+        col.prop(self, "project_prefix")
+        col.prop(self, "project_postfix")
 
 
 class HeartbeatQueueProcessor(threading.Thread):
@@ -289,6 +301,7 @@ def handle_activity(is_write=False):
         _projectname = os.path.splitext(_filename)[0] # cut away extension
         _projectname = _projectname.rstrip(truncate_chars) # strip trailing configured characters (from preferences-menu)
         _projectname = path_leaf(_projectname) # remove path from the (full) filename
+        _projectname = blender_settings.project_prefix + _projectname + blender_settings.project_postfix
         log(INFO, "project-name in WakaTime: {}", _projectname)
 
         _last_hb = {'entity': _filename, 'project': _projectname, 'timestamp': timestamp, 'is_write': is_write}

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -1,5 +1,4 @@
 import json
-import ntpath
 import os
 import sys
 import threading
@@ -328,12 +327,6 @@ def enough_time_passed(now, is_write):
             or (now - _last_hb['timestamp'] > (2 if is_write else HEARTBEAT_FREQUENCY * 60)))
 
 
-# removing path from the full filename... this should work under all OS
-def path_leaf(path):
-    head, tail = ntpath.split(path)
-    return tail or ntpath.basename(head)
-
-
 def handle_activity(is_write=False):
     global _last_hb
     if SHOW_KEY_DIALOG or not SETTINGS.get(settings, 'api_key', fallback=''):
@@ -353,7 +346,7 @@ def handle_activity(is_write=False):
             _projectname = os.path.basename(os.path.dirname(_filename)) # grab the name of the directory
         else:
             _projectname = os.path.splitext(_filename)[0] # cut away the (.blend) extension
-            _projectname = path_leaf(_projectname) # remove (the full) path from the filename
+            _projectname = os.path.basename(_projectname) # remove (the full) path from the filename
         _projectname = _projectname.rstrip(truncate_chars) # remove trailing characters (as configured in "Preferences")
         # tune project-name with pre- and postfix
         _projectname = blender_settings.project_prefix + _projectname + blender_settings.project_postfix

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -336,10 +336,7 @@ def handle_activity(is_write=False):
     if _filename and (_filename != last_file or enough_time_passed(timestamp, is_write)):
         # use file- or folder-name to derive a project-name
         blender_settings = bpy.context.preferences.addons[__name__].preferences
-        if hasattr(blender_settings, "truncate_trail"):
-            truncate_chars = blender_settings.truncate_trail
-        else:
-            truncate_chars = ""
+        truncate_chars = blender_settings.truncate_trail
         log(DEBUG, "truncate trailing chars from settings: {}", truncate_chars)
         # project-folder or blend-filename?
         if blender_settings.use_project_folder:

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -325,20 +325,24 @@ def enough_time_passed(now, is_write):
 
 
 @lru_cache
-def guessProjectName(filename):
+def guessProjectName(
+    filename,
+    truncate_trail,
+    use_project_folder,
+    project_prefix,
+    project_postfix
+):
     # use file- or folder-name to derive a project-name
-    blender_settings = bpy.context.preferences.addons[__name__].preferences
-    truncate_chars = blender_settings.truncate_trail
     log(DEBUG, "truncate trailing chars from settings: {}", truncate_chars)
     # project-folder or blend-filename?
-    if blender_settings.use_project_folder:
+    if use_project_folder:
         _name = os.path.basename(os.path.dirname(filename)) # grab the name of the directory
     else:
         _name = os.path.splitext(filename)[0] # cut away the (.blend) extension
         _name = os.path.basename(_name) # remove (the full) path from the filename
-    _name = _name.rstrip(truncate_chars) # remove trailing characters (as configured in "Preferences")
+    _name = _name.rstrip(truncate_trail) # remove trailing characters (as configured in "Preferences")
     # tune project-name with pre- and postfix
-    _name = blender_settings.project_prefix + _name + blender_settings.project_postfix
+    _name = f"{project_prefix}{_name}{project_postfix}"
     log(INFO, "project-name in WakaTime: {}", _name)
     return _name
 
@@ -349,7 +353,14 @@ def handle_activity(is_write=False):
     timestamp = time.time()
     last_file = _last_hb['entity'] if _last_hb is not None else ''
     if _filename and (_filename != last_file or enough_time_passed(timestamp, is_write)):
-        _projectname = guessProjectName(_filename)
+        blender_settings = bpy.context.preferences.addons[__name__].preferences
+        _projectname = guessProjectName(
+            _filename,
+            blender_settings.truncate_trail,
+            blender_settings.use_project_folder,
+            blender_settings.project_prefix,
+            blender_settings.project_postfix
+        )
         _last_hb = {'entity': _filename, 'project': _projectname, 'timestamp': timestamp, 'is_write': is_write}
         _heartbeats.put_nowait(_last_hb)
 

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -12,7 +12,6 @@ from zipfile import ZipFile
 import bpy
 from bpy.app.handlers import persistent
 from bpy.props import (BoolProperty, StringProperty)
-from bpy.utils import register_class
 
 import ssl
 import urllib
@@ -357,11 +356,11 @@ def register():
     global REGISTERED
     log(INFO, 'Initializing WakaTime plugin v{}', __version__)
     setup()
+    bpy.utils.register_class(WakaTimePreferences)
     bpy.utils.register_class(API_Key_Dialog)
     bpy.app.handlers.load_post.append(load_handler)
     bpy.app.handlers.save_post.append(save_handler)
     bpy.app.handlers.depsgraph_update_pre.append(activity_handler)
-    register_class(WakaTimePreferences)
     REGISTERED = True
 
 
@@ -377,7 +376,7 @@ def unregister():
     _heartbeats.put_nowait(None)
     _heartbeats.task_done()
     _hb_processor.join()
-    unregister_class(WakaTimePreferences)
+    bpy.utils.unregister_class(WakaTimePreferences)
 
 
 if __name__ == '__main__':

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -356,7 +356,7 @@ def handle_activity(is_write=False):
         log(DEBUG, "truncate trailing chars from settings: {}", truncate_chars)
         # project-folder or blend-filename?
         if blender_settings.use_project_folder:
-            _projectname=os.path.basename(os.path.dirname(_filename)) # grab the name of the directory
+            _projectname = os.path.basename(os.path.dirname(_filename)) # grab the name of the directory
         else:
             _projectname = os.path.splitext(_filename)[0] # cut away the (.blend) extension
             _projectname = path_leaf(_projectname) # remove (the full) path from the filename

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -332,8 +332,6 @@ def guessProjectName(
     project_prefix,
     project_postfix
 ):
-    # use file- or folder-name to derive a project-name
-    log(DEBUG, "truncate trailing chars from settings: {}", truncate_chars)
     # project-folder or blend-filename?
     if use_project_folder:
         _name = os.path.basename(os.path.dirname(filename)) # grab the name of the directory

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -129,7 +129,7 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     use_project_folder: BoolProperty(
         name = "Use folder-name as project-name",
         default = _default_use_project_folder,
-        description="Will use the name of the folder/directory-name as the project-name.\n\nExample: if selected, filename 'birthday_project/test_01.blend' will result in project-name 'birthday_project'\n\nHint: if not activated, the blender-filename without the blend-extension is used.\n\nDefault: " + str(bool(_default_use_project_folder)))
+        description = f"Will use the name of the folder/directory-name as the project-name.\n\nExample: if selected, filename 'birthday_project/test_01.blend' will result in project-name 'birthday_project'\n\nHint: if not activated, the blender-filename without the blend-extension is used.\n\nDefault: {bool(_default_use_project_folder)}")
     truncate_trail: StringProperty(
         name = "Cut trailing characters",
         default = _default_chars,

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -118,7 +118,7 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     always_overwrite_name: BoolProperty(
         name = "Overwrite project-discovery with the name from below",
         default = _default_always_overwrite_projectname,
-        description = "WakaTime will guess the project-name (e.g. from the git-repo). Checking this box will overwrite this auto-discovered name (with the name according to the rules below).\n\nHint: when not working with git, the project's name will always be set according to the rules below.\n\nDefault: {bool(_default_always_overwrite_projectname)}")
+        description = f"WakaTime will guess the project-name (e.g. from the git-repo). Checking this box will overwrite this auto-discovered name (with the name according to the rules below).\n\nHint: when not working with git, the project's name will always be set according to the rules below.\n\nDefault: {bool(_default_always_overwrite_projectname)}")
     use_project_folder: BoolProperty(
         name = "Use folder-name as project-name",
         default = _default_use_project_folder,
@@ -126,15 +126,15 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     truncate_trail: StringProperty(
         name = "Cut trailing characters",
         default = _default_chars,
-        description="With the project-name extracted (from folder- or filename), these trailing characters will be removed too.\n\nExample: filename 'birthday_01_test_02.blend' will result in project-name 'birthday_01_test'\n\nDefault: '" + _def_chars + "'")
+        description = f"With the project-name extracted (from folder- or filename), these trailing characters will be removed too.\n\nExample: filename 'birthday_01_test_02.blend' will result in project-name 'birthday_01_test'\n\nDefault: '{_def_chars}'")
     project_prefix: StringProperty(
         name = "project-name prefix",
         default = _default_prefix,
-        description="This text will be attached in front of the project-name.\n\nDefault: '" + _def_prefix + "'")
+        description = f"This text will be attached in front of the project-name.\n\nDefault: '{_def_prefix}'")
     project_postfix: StringProperty(
         name = "project-name postfix",
         default = _default_postfix,
-        description="This text will be attached at the end of the project-name, after the trailing characters were removed.\n\nDefault: '" + _def_postfix + "'")
+        description = f"This text will be attached at the end of the project-name, after the trailing characters were removed.\n\nDefault: '{_def_postfix}'")
 
     def draw(self, context):
         layout = self.layout

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -112,9 +112,6 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     _default_postfix = ''
     _default_use_project_folder = 0
     bl_idname = __name__
-    _def_chars = _default_chars if _default_chars else "<empty>"
-    _def_prefix = _default_prefix if _default_prefix else "<empty>"
-    _def_postfix = _default_postfix if _default_postfix else "<empty>"
     always_overwrite_name: BoolProperty(
         name = "Overwrite project-discovery with the name from below",
         default = _default_always_overwrite_projectname,
@@ -126,15 +123,15 @@ class WakaTimePreferences(bpy.types.AddonPreferences):
     truncate_trail: StringProperty(
         name = "Cut trailing characters",
         default = _default_chars,
-        description = f"With the project-name extracted (from folder- or filename), these trailing characters will be removed too.\n\nExample: filename 'birthday_01_test_02.blend' will result in project-name 'birthday_01_test'\n\nDefault: '{_def_chars}'")
+        description = f"With the project-name extracted (from folder- or filename), these trailing characters will be removed too.\n\nExample: filename 'birthday_01_test_02.blend' will result in project-name 'birthday_01_test'\n\nDefault: {_default_chars or '<empty>'}")
     project_prefix: StringProperty(
         name = "project-name prefix",
         default = _default_prefix,
-        description = f"This text will be attached in front of the project-name.\n\nDefault: '{_def_prefix}'")
+        description = f"This text will be attached in front of the project-name.\n\nDefault: '{_default_prefix or '<empty>'}'")
     project_postfix: StringProperty(
         name = "project-name postfix",
         default = _default_postfix,
-        description = f"This text will be attached at the end of the project-name, after the trailing characters were removed.\n\nDefault: '{_def_postfix}'")
+        description = f"This text will be attached at the end of the project-name, after the trailing characters were removed.\n\nDefault: '{_default_postfix or '<empty>'}'")
 
     def draw(self, context):
         layout = self.layout
@@ -327,7 +324,7 @@ def enough_time_passed(now, is_write):
             or (now - _last_hb['timestamp'] > (2 if is_write else HEARTBEAT_FREQUENCY * 60)))
 
 
-@lru_cache(maxsize=4)
+@lru_cache
 def guessProjectName(filename):
     # use file- or folder-name to derive a project-name
     blender_settings = bpy.context.preferences.addons[__name__].preferences

--- a/WakaTime.py
+++ b/WakaTime.py
@@ -324,7 +324,7 @@ def enough_time_passed(now, is_write):
             or (now - _last_hb['timestamp'] > (2 if is_write else HEARTBEAT_FREQUENCY * 60)))
 
 
-@lru_cache
+@lru_cache(maxsize=128)
 def guessProjectName(
     filename,
     truncate_trail,


### PR DESCRIPTION
Thank you for the WakaTime-AddOn. :smiley: 

For me it unfortunately never transmitted any project-name to WakaTime, always just accumulating time under "Unknown Project".

So I added some kind of project-name "detection" and transmission.
Description of the functionality is in the [README.md](https://github.com/HannesBln/WakatimeBlender/blob/master/README.md).

Programmatically the "core" was not changed much:
1. The `--project` command-line argument was added when calling the wakatime-client.
2. `handle_activity` was extended to extract the project's name from filename or directory-name. After the extraction the name can be truncated (from the end of the string),  post- and prefix can be added to the name too. All this can be configured in the "Add-Ons" -Menu.

**Attention**: This was tested under Linux only! :neutral_face: 