### PR TITLE
Updated to support new Go wakatime-cli

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@ from .wakatime_blender.preferences import (
     WakatimeProjectProperties,
 )
 from .wakatime_blender.wakatime_downloader import (
-    ForceWakatimeDownload,
+    # ForceWakatimeDownload
     WakatimeDownloader,
 )
 
@@ -19,7 +19,7 @@ bl_info = {
     "category": "Development",
     "author": "Allis Tauri <allista@gmail.com>",
     "version": (2, 0, 1),
-    "blender": (2, 93, 0),
+    "blender": (3, 0, 0),
     "description": "Submits your working stats to the Wakatime time tracking service.",
     "tracker_url": "https://github.com/allista/WakatimeBlender/issues",
 }
@@ -56,7 +56,7 @@ def activity_handler(_):
 
 def menu(self, _context):
     self.layout.operator(PreferencesDialog.bl_idname)
-    self.layout.operator(ForceWakatimeDownload.bl_idname)
+    # self.layout.operator(ForceWakatimeDownload.bl_idname)
 
 
 def register():
@@ -66,10 +66,10 @@ def register():
     try:
         log(INFO, "Initializing Wakatime plugin v{}", __version__)
         WakatimeProjectProperties.load_defaults()
-        bpy.utils.register_class(ForceWakatimeDownload)
+        # bpy.utils.register_class(ForceWakatimeDownload)
         bpy.utils.register_class(WakatimeProjectProperties)
         bpy.utils.register_class(PreferencesDialog)
-        bpy.types.TOPBAR_MT_app_system.append(menu)
+        bpy.types.TOPBAR_MT_blender_system.append(menu)
         bpy.app.handlers.load_post.append(load_handler)
         bpy.app.handlers.save_post.append(save_handler)
         bpy.app.handlers.depsgraph_update_pre.append(activity_handler)
@@ -90,11 +90,11 @@ def unregister():
         return
     try:
         log(INFO, "Unregistering Wakatime plugin v{}", __version__)
-        bpy.types.TOPBAR_MT_app_system.remove(menu)
+        bpy.types.TOPBAR_MT_blender_system.remove(menu)
         bpy.app.handlers.load_post.remove(load_handler)
         bpy.app.handlers.save_post.remove(save_handler)
         bpy.app.handlers.depsgraph_update_pre.remove(activity_handler)
-        bpy.utils.unregister_class(ForceWakatimeDownload)
+        # bpy.utils.unregister_class(ForceWakatimeDownload)
         bpy.utils.unregister_class(PreferencesDialog)
         heartbeat_queue.shutdown()
         heartbeat_queue.join(heartbeat_queue.POLL_INTERVAL * 3)

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ bl_info = {
     "category": "Development",
     "author": "Allis Tauri <allista@gmail.com>",
     "version": (2, 0, 1),
-    "blender": (3, 0, 0),
+    "blender": (3, 3, 0),
     "description": "Submits your working stats to the Wakatime time tracking service.",
     "tracker_url": "https://github.com/allista/WakatimeBlender/issues",
 }

--- a/wakatime_blender/heartbeat_queue.py
+++ b/wakatime_blender/heartbeat_queue.py
@@ -110,7 +110,6 @@ class HeartbeatQueue(threading.Thread):
     ):
         ua = f"blender/{bpy.app.version_string.split()[0]} blender-wakatime/{self._version}"
         cmd = [
-            sys.executable,
             settings.API_CLIENT,
             "--entity",
             heartbeat.entity,

--- a/wakatime_blender/heartbeat_queue.py
+++ b/wakatime_blender/heartbeat_queue.py
@@ -10,6 +10,7 @@ from subprocess import PIPE, Popen, STDOUT
 from typing import List, Optional
 
 import bpy
+from wakatime_blender.wakatime_downloader import getCliLocation
 from .log import DEBUG, ERROR, INFO, log
 from . import settings
 from .utils import u
@@ -110,7 +111,7 @@ class HeartbeatQueue(threading.Thread):
     ):
         ua = f"blender/{bpy.app.version_string.split()[0]} blender-wakatime/{self._version}"
         cmd = [
-            settings.API_CLIENT,
+            getCliLocation(),
             "--entity",
             heartbeat.entity,
             "--time",

--- a/wakatime_blender/heartbeat_queue.py
+++ b/wakatime_blender/heartbeat_queue.py
@@ -10,7 +10,7 @@ from subprocess import PIPE, Popen, STDOUT
 from typing import List, Optional
 
 import bpy
-from wakatime_blender.wakatime_downloader import getCliLocation
+from .wakatime_downloader import getCliLocation
 from .log import DEBUG, ERROR, INFO, log
 from . import settings
 from .utils import u

--- a/wakatime_blender/settings.py
+++ b/wakatime_blender/settings.py
@@ -5,13 +5,6 @@ from typing import Any, Callable, Optional, TypeVar
 USER_HOME = os.path.expanduser("~")
 PLUGIN_DIR = os.path.dirname(os.path.realpath(__file__))
 RESOURCES_DIR = os.path.join(USER_HOME, ".wakatime")
-API_CLIENT_DIR = os.path.join(RESOURCES_DIR, "wakatime-runtime")
-# using the legacy python client to avoid the need to figure out
-# which binary to download for particular platform
-API_CLIENT_URL = "https://github.com/wakatime/wakatime/archive/master.zip"
-API_CLIENT = os.path.join(
-    API_CLIENT_DIR, "legacy-python-cli-master", "wakatime", "cli.py"
-)
 # default wakatime config for legacy python client
 FILENAME = os.path.join(USER_HOME, ".wakatime.cfg")
 # default section in wakatime config

--- a/wakatime_blender/wakatime_downloader.py
+++ b/wakatime_blender/wakatime_downloader.py
@@ -1,21 +1,43 @@
 import os
+import sys
 import shutil
 import ssl
 import threading
 import urllib
 import urllib.error
 import urllib.request
+import traceback
+import platform
+import subprocess
+import configparser
+import json
+import re
+
 from time import sleep
 from typing import NamedTuple, Optional, Tuple
 from zipfile import ZipFile
+from subprocess import STDOUT, PIPE, Popen
 
 import bpy
 from . import settings
-from .log import ERROR, INFO, log
+from .log import DEBUG, ERROR, INFO, log
 from .preferences import WakatimeProjectProperties
+
+'''
+Uses lots of code from the Sublime Text addon to add support for the Go wakatime-cli.
+Rest of the code is mostly original from allista/WakatimeBlender
+'''
+
+GITHUB_RELEASES_STABLE_URL = 'https://api.github.com/repos/wakatime/wakatime-cli/releases/latest'
+GITHUB_DOWNLOAD_PREFIX = 'https://github.com/wakatime/wakatime-cli/releases/download'
+INTERNAL_CONFIG_FILE = os.path.join(settings.USER_HOME, '.wakatime-internal.cfg')
+
+LATEST_CLI_VERSION = None
+WAKATIME_CLI_LOCATION = None
 
 ReportArgs = Tuple[set, str]
 
+is_win = platform.system() == 'Windows'
 
 class Status(NamedTuple):
     message: str
@@ -25,120 +47,286 @@ class Status(NamedTuple):
         return {self.level or INFO}, self.message
 
 
+class Popen(subprocess.Popen):
+    """Patched Popen to prevent opening cmd window on Windows platform."""
+
+    def __init__(self, *args, **kwargs):
+        startupinfo = kwargs.get('startupinfo')
+        if is_win or True:
+            try:
+                startupinfo = startupinfo or subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            except AttributeError:
+                pass
+        kwargs['startupinfo'] = startupinfo
+        super(Popen, self).__init__(*args, **kwargs)
+
 class WakatimeDownloader(threading.Thread):
-    """Downloads Wakatime client if it isn't already downloaded."""
+    """Non-blocking thread for downloading latest wakatime-cli from GitHub.
+    """
 
-    _lock = threading.Lock()
-
-    def __init__(self, force=False) -> None:
+    def __init__(self, force=False):
         super().__init__()
-        self.daemon = True
         self._force = force
-        self._status_lock = threading.Lock()
-        self._status: Optional[Status] = None
-
-    def _set_status(self, message: str, level: str = INFO) -> None:
-        with self._status_lock:
-            self._status = Status(message, level)
-        log(level, message)
-        sleep(0)
-
-    def status(self) -> Optional[ReportArgs]:
-        with self._status_lock:
-            return self._status.as_report() if self._status else None
 
     def run(self):
-        with self._lock:
-            if not os.path.isdir(settings.RESOURCES_DIR):
-                # there is no resources directory,
-                # attempting to create one
+        log(INFO, 'Downloading wakatime-cli...')
+
+        if not os.path.exists(settings.RESOURCES_DIR):
+            os.makedirs(settings.RESOURCES_DIR)
+
+        if isCliInstalled():
+            if self._force:
                 try:
-                    os.mkdir(settings.RESOURCES_DIR)
-                except Exception as e:
-                    self._set_status(
-                        f"Unable to create directory:\n{settings.RESOURCES_DIR}\n{e}",
-                        ERROR,
-                    )
-                    return
-            # check if the client is already downloaded,
-            # or the downloading is forced
-            if not self._force and os.path.isfile(settings.API_CLIENT):
-                self._set_status("Found Wakatime client")
+                    os.remove(getCliLocation())
+                except:
+                    log(DEBUG, traceback.format_exc())
+            else:
+                log(INFO, 'wakatime-cli already installed')
                 return
-            if os.path.isdir(settings.API_CLIENT_DIR):
-                # remove wakatime client dir if it is present
-                self._set_status("Removing old runtime...")
-                shutil.rmtree(settings.API_CLIENT_DIR, ignore_errors=True)
-            # there is no Wakatime client present in the directory,
-            # or the downloading is forced
-            self._set_status("Downloading Wakatime...")
-            # the path to the zipped Wakatime client
-            zip_file_path = os.path.join(settings.RESOURCES_DIR, "wakatime-master.zip")
-            # issue a new request to download said client
-            req = urllib.request.Request(settings.API_CLIENT_URL)
-            context = ssl._create_unverified_context()
+
+        try:
+            url = cliDownloadUrl()
+            log(DEBUG, 'Downloading wakatime-cli from {url}'.format(url=url))
+            zip_file = os.path.join(settings.RESOURCES_DIR, 'wakatime-cli.zip')
+            download(url, zip_file)
+
+            log(INFO, 'Extracting wakatime-cli...')
+            with ZipFile(zip_file) as zf:
+                zf.extractall(settings.RESOURCES_DIR)
+
+            if not is_win:
+                os.chmod(getCliLocation(), 509)  # 755
+
             try:
-                # read and save the file to said zip file
-                with urllib.request.urlopen(req, context=context) as r, open(
-                    zip_file_path, "wb+"
-                ) as fo:
-                    # as the input file is in bytes, the write mode has
-                    # to be bytes as well, that's why it's `wb+`
-                    fo.write(r.read())
-            except urllib.error.HTTPError as e:
-                self._set_status(
-                    "Could not download the Wakatime client. There was an HTTP error.",
-                    ERROR,
-                )
-                raise e
-            except urllib.error.URLError as e:
-                self._set_status(
-                    "Could not download the Wakatime client. There was a URL error. "
-                    "Maybe there is a problem with your Internet connection?",
-                    ERROR,
-                )
-                raise e
-            self._set_status("Extracting Wakatime...")
-            with ZipFile(zip_file_path) as zf:
-                zf.extractall(settings.API_CLIENT_DIR)
+                os.remove(os.path.join(settings.RESOURCES_DIR, 'wakatime-cli.zip'))
+            except:
+                log(DEBUG, traceback.format_exc())
+        except:
+            log(DEBUG, traceback.format_exc())
+
+        log(INFO, 'Finished extracting wakatime-cli.')
+
+
+def parseConfigFile(configFile):
+    """Returns a configparser.SafeConfigParser instance with configs
+    read from the config file. Default location of the config file is
+    at ~/.wakatime.cfg.
+    """
+
+    configs = configparser.SafeConfigParser()
+    try:
+        with open(configFile, 'r', encoding='utf-8') as fh:
             try:
-                os.remove(zip_file_path)
-            except Exception:
-                self._set_status(
-                    "Unable to remove wakatime archive",
-                    ERROR,
-                )
-            self._set_status("Wakatime client downloaded")
+                configs.readfp(fh)
+                return configs
+            except configparser.Error:
+                log(ERROR, traceback.format_exc())
+                return None
+    except IOError:
+        log(DEBUG, "Error: Could not read from config file {0}\n".format(configFile))
+        return configs
 
+def getCliLocation():
+    global WAKATIME_CLI_LOCATION
 
-class ForceWakatimeDownload(bpy.types.Operator):
-    bl_idname = "ui.download_wakatime_client"
-    bl_label = "Download wakatime client"
-    bl_description = f"Force (re)downloading of the wakatime client runtime from {settings.API_CLIENT_URL}"
+    if not WAKATIME_CLI_LOCATION:
+        binary = 'wakatime-cli-{osname}-{arch}{ext}'.format(
+            osname=platform.system().lower(),
+            arch=architecture(),
+            ext='.exe' if is_win else '',
+        )
+        WAKATIME_CLI_LOCATION = os.path.join(settings.RESOURCES_DIR, binary)
 
-    _last_status: Optional[ReportArgs] = None
-    _downloader: Optional[WakatimeDownloader] = None
+    return WAKATIME_CLI_LOCATION
 
-    @classmethod
-    def poll(cls, _context):
-        return WakatimeProjectProperties.instance() is not None
+def architecture():
+    arch = platform.machine() or platform.processor()
+    if arch == 'armv7l':
+        return 'arm'
+    if arch == 'aarch64':
+        return 'arm64'
+    if 'arm' in arch:
+        return 'arm64' if sys.maxsize > 2**32 else 'arm'
+    return 'amd64' if sys.maxsize > 2**32 else '386'
 
-    def invoke(self, context, _event):
-        self._last_status = None
-        self._downloader = None
-        context.window_manager.modal_handler_add(self)
-        return {"RUNNING_MODAL"}
+def isCliInstalled():
+    return os.path.exists(getCliLocation())
 
-    def modal(self, _context, _event):
-        if self._downloader is None:
-            self._downloader = WakatimeDownloader(force=True)
-            self._downloader.start()
-            return {"PASS_THROUGH"}
-        status = self._downloader.status()
-        if status and status != self._last_status:
-            self._last_status = status
-            self.report(*status)
-        if self._downloader.is_alive():
-            return {"PASS_THROUGH"}
-        self._downloader = None
-        return {"FINISHED"}
+def isCliLatest():
+    if not isCliInstalled():
+        return False
+
+    args = [getCliLocation(), '--version']
+    try:
+        stdout, stderr = Popen(args, stdout=PIPE, stderr=PIPE).communicate()
+    except:
+        return False
+    stdout = (stdout or b'') + (stderr or b'')
+    localVer = extractVersion(stdout.decode('utf-8'))
+    if not localVer:
+        log(DEBUG, 'Local wakatime-cli version not found.')
+        return False
+
+    log(INFO, 'Current wakatime-cli version is %s' % localVer)
+    log(INFO, 'Checking for updates to wakatime-cli...')
+
+    remoteVer = getLatestCliVersion()
+
+    if not remoteVer:
+        return True
+
+    if remoteVer == localVer:
+        log(INFO, 'wakatime-cli is up to date.')
+        return True
+
+    log(INFO, 'Found an updated wakatime-cli %s' % remoteVer)
+    return False
+
+def getLatestCliVersion():
+    global LATEST_CLI_VERSION
+
+    if LATEST_CLI_VERSION:
+        return LATEST_CLI_VERSION
+
+    configs, last_modified, last_version = None, None, None
+    try:
+        configs = parseConfigFile(INTERNAL_CONFIG_FILE)
+        if configs:
+            if configs.has_option('internal', 'cli_version'):
+                last_version = configs.get('internal', 'cli_version')
+            if last_version and configs.has_option('internal', 'cli_version_last_modified'):
+                last_modified = configs.get('internal', 'cli_version_last_modified')
+    except:
+        log(DEBUG, traceback.format_exc())
+
+    try:
+        headers, contents, code = request(GITHUB_RELEASES_STABLE_URL, last_modified=last_modified)
+
+        log(DEBUG, 'GitHub API Response {0}'.format(code))
+
+        if code == 304:
+            LATEST_CLI_VERSION = last_version
+            return last_version
+
+        data = json.loads(contents.decode('utf-8'))
+
+        ver = data['tag_name']
+        log(DEBUG, 'Latest wakatime-cli version from GitHub: {0}'.format(ver))
+
+        if configs:
+            last_modified = headers.get('Last-Modified')
+            if not configs.has_section('internal'):
+                configs.add_section('internal')
+            configs.set('internal', 'cli_version', ver)
+            configs.set('internal', 'cli_version_last_modified', last_modified)
+            with open(INTERNAL_CONFIG_FILE, 'w', encoding='utf-8') as fh:
+                configs.write(fh)
+
+        LATEST_CLI_VERSION = ver
+        return ver
+    except:
+        log(DEBUG, traceback.format_exc())
+        return None
+
+def extractVersion(text):
+    pattern = re.compile(r"([0-9]+\.[0-9]+\.[0-9]+)")
+    match = pattern.search(text)
+    if match:
+        return 'v{ver}'.format(ver=match.group(1))
+    return None
+
+def cliDownloadUrl():
+    osname = platform.system().lower()
+    arch = architecture()
+
+    validCombinations = [
+      'darwin-amd64',
+      'darwin-arm64',
+      'freebsd-386',
+      'freebsd-amd64',
+      'freebsd-arm',
+      'linux-386',
+      'linux-amd64',
+      'linux-arm',
+      'linux-arm64',
+      'netbsd-386',
+      'netbsd-amd64',
+      'netbsd-arm',
+      'openbsd-386',
+      'openbsd-amd64',
+      'openbsd-arm',
+      'openbsd-arm64',
+      'windows-386',
+      'windows-amd64',
+      'windows-arm64',
+    ]
+    check = '{osname}-{arch}'.format(osname=osname, arch=arch)
+    if check not in validCombinations:
+        reportMissingPlatformSupport(osname, arch)
+
+    version = getLatestCliVersion()
+
+    return '{prefix}/{version}/wakatime-cli-{osname}-{arch}.zip'.format(
+        prefix=GITHUB_DOWNLOAD_PREFIX,
+        version=version,
+        osname=osname,
+        arch=arch,
+    )
+
+def reportMissingPlatformSupport(osname, arch):
+    url = 'https://api.wakatime.com/api/v1/cli-missing?osname={osname}&architecture={arch}&plugin=sublime'.format(
+        osname=osname,
+        arch=arch,
+    )
+    request(url)
+
+def request(url, last_modified=None):
+    proxy = False # TODO: Support for Proxy (?)
+    if proxy:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({
+            'http': proxy,
+            'https': proxy,
+        }))
+    else:
+        opener = urllib.request.build_opener()
+
+    headers = [('User-Agent', 'github.com/wakatime/sublime-wakatime')]
+    if last_modified:
+        headers.append(('If-Modified-Since', last_modified))
+
+    opener.addheaders = headers
+
+    urllib.request.install_opener(opener)
+
+    try:
+        resp = urllib.request.urlopen(url)
+        headers = resp.headers
+        return headers, resp.read(), resp.getcode()
+    except urllib.error.HTTPError as err:
+        if err.code == 304:
+            return None, None, 304
+        log(DEBUG, err.read().decode())
+        raise
+    except IOError:
+        raise
+
+def download(url, filePath):
+    proxy = False # TODO: Support for Proxy (?)
+    if proxy:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({
+            'http': proxy,
+            'https': proxy,
+        }))
+    else:
+        opener = urllib.request.build_opener()
+    opener.addheaders = [('User-Agent', 'github.com/wakatime/sublime-wakatime')]
+
+    urllib.request.install_opener(opener)
+
+    try:
+        urllib.request.urlretrieve(url, filePath)
+    except IOError:
+        raise
+
+# Removed force downloader. Addon still checks on each startup.

--- a/wakatime_blender/wakatime_downloader.py
+++ b/wakatime_blender/wakatime_downloader.py
@@ -23,21 +23,24 @@ from . import settings
 from .log import DEBUG, ERROR, INFO, log
 from .preferences import WakatimeProjectProperties
 
-'''
+"""
 Uses lots of code from the Sublime Text addon to add support for the Go wakatime-cli.
 Rest of the code is mostly original from allista/WakatimeBlender
-'''
+"""
 
-GITHUB_RELEASES_STABLE_URL = 'https://api.github.com/repos/wakatime/wakatime-cli/releases/latest'
-GITHUB_DOWNLOAD_PREFIX = 'https://github.com/wakatime/wakatime-cli/releases/download'
-INTERNAL_CONFIG_FILE = os.path.join(settings.USER_HOME, '.wakatime-internal.cfg')
+GITHUB_RELEASES_STABLE_URL = (
+    "https://api.github.com/repos/wakatime/wakatime-cli/releases/latest"
+)
+GITHUB_DOWNLOAD_PREFIX = "https://github.com/wakatime/wakatime-cli/releases/download"
+INTERNAL_CONFIG_FILE = os.path.join(settings.USER_HOME, ".wakatime-internal.cfg")
 
 LATEST_CLI_VERSION = None
 WAKATIME_CLI_LOCATION = None
 
 ReportArgs = Tuple[set, str]
 
-is_win = platform.system() == 'Windows'
+is_win = platform.system() == "Windows"
+
 
 class Status(NamedTuple):
     message: str
@@ -51,26 +54,26 @@ class Popen(subprocess.Popen):
     """Patched Popen to prevent opening cmd window on Windows platform."""
 
     def __init__(self, *args, **kwargs):
-        startupinfo = kwargs.get('startupinfo')
+        startupinfo = kwargs.get("startupinfo")
         if is_win or True:
             try:
                 startupinfo = startupinfo or subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             except AttributeError:
                 pass
-        kwargs['startupinfo'] = startupinfo
+        kwargs["startupinfo"] = startupinfo
         super(Popen, self).__init__(*args, **kwargs)
 
+
 class WakatimeDownloader(threading.Thread):
-    """Non-blocking thread for downloading latest wakatime-cli from GitHub.
-    """
+    """Non-blocking thread for downloading latest wakatime-cli from GitHub."""
 
     def __init__(self, force=False):
         super().__init__()
         self._force = force
 
     def run(self):
-        log(INFO, 'Downloading wakatime-cli...')
+        log(INFO, "Downloading wakatime-cli...")
 
         if not os.path.exists(settings.RESOURCES_DIR):
             os.makedirs(settings.RESOURCES_DIR)
@@ -82,16 +85,16 @@ class WakatimeDownloader(threading.Thread):
                 except:
                     log(DEBUG, traceback.format_exc())
             else:
-                log(INFO, 'wakatime-cli already installed')
+                log(INFO, "wakatime-cli already installed")
                 return
 
         try:
             url = cliDownloadUrl()
-            log(DEBUG, 'Downloading wakatime-cli from {url}'.format(url=url))
-            zip_file = os.path.join(settings.RESOURCES_DIR, 'wakatime-cli.zip')
+            log(DEBUG, "Downloading wakatime-cli from {url}".format(url=url))
+            zip_file = os.path.join(settings.RESOURCES_DIR, "wakatime-cli.zip")
             download(url, zip_file)
 
-            log(INFO, 'Extracting wakatime-cli...')
+            log(INFO, "Extracting wakatime-cli...")
             with ZipFile(zip_file) as zf:
                 zf.extractall(settings.RESOURCES_DIR)
 
@@ -99,13 +102,13 @@ class WakatimeDownloader(threading.Thread):
                 os.chmod(getCliLocation(), 509)  # 755
 
             try:
-                os.remove(os.path.join(settings.RESOURCES_DIR, 'wakatime-cli.zip'))
+                os.remove(os.path.join(settings.RESOURCES_DIR, "wakatime-cli.zip"))
             except:
                 log(DEBUG, traceback.format_exc())
         except:
             log(DEBUG, traceback.format_exc())
 
-        log(INFO, 'Finished extracting wakatime-cli.')
+        log(INFO, "Finished extracting wakatime-cli.")
 
 
 def parseConfigFile(configFile):
@@ -116,7 +119,7 @@ def parseConfigFile(configFile):
 
     configs = configparser.SafeConfigParser()
     try:
-        with open(configFile, 'r', encoding='utf-8') as fh:
+        with open(configFile, "r", encoding="utf-8") as fh:
             try:
                 configs.readfp(fh)
                 return configs
@@ -127,49 +130,53 @@ def parseConfigFile(configFile):
         log(DEBUG, "Error: Could not read from config file {0}\n".format(configFile))
         return configs
 
+
 def getCliLocation():
     global WAKATIME_CLI_LOCATION
 
     if not WAKATIME_CLI_LOCATION:
-        binary = 'wakatime-cli-{osname}-{arch}{ext}'.format(
+        binary = "wakatime-cli-{osname}-{arch}{ext}".format(
             osname=platform.system().lower(),
             arch=architecture(),
-            ext='.exe' if is_win else '',
+            ext=".exe" if is_win else "",
         )
         WAKATIME_CLI_LOCATION = os.path.join(settings.RESOURCES_DIR, binary)
 
     return WAKATIME_CLI_LOCATION
 
+
 def architecture():
     arch = platform.machine() or platform.processor()
-    if arch == 'armv7l':
-        return 'arm'
-    if arch == 'aarch64':
-        return 'arm64'
-    if 'arm' in arch:
-        return 'arm64' if sys.maxsize > 2**32 else 'arm'
-    return 'amd64' if sys.maxsize > 2**32 else '386'
+    if arch == "armv7l":
+        return "arm"
+    if arch == "aarch64":
+        return "arm64"
+    if "arm" in arch:
+        return "arm64" if sys.maxsize > 2**32 else "arm"
+    return "amd64" if sys.maxsize > 2**32 else "386"
+
 
 def isCliInstalled():
     return os.path.exists(getCliLocation())
+
 
 def isCliLatest():
     if not isCliInstalled():
         return False
 
-    args = [getCliLocation(), '--version']
+    args = [getCliLocation(), "--version"]
     try:
         stdout, stderr = Popen(args, stdout=PIPE, stderr=PIPE).communicate()
     except:
         return False
-    stdout = (stdout or b'') + (stderr or b'')
-    localVer = extractVersion(stdout.decode('utf-8'))
+    stdout = (stdout or b"") + (stderr or b"")
+    localVer = extractVersion(stdout.decode("utf-8"))
     if not localVer:
-        log(DEBUG, 'Local wakatime-cli version not found.')
+        log(DEBUG, "Local wakatime-cli version not found.")
         return False
 
-    log(INFO, 'Current wakatime-cli version is %s' % localVer)
-    log(INFO, 'Checking for updates to wakatime-cli...')
+    log(INFO, "Current wakatime-cli version is %s" % localVer)
+    log(INFO, "Checking for updates to wakatime-cli...")
 
     remoteVer = getLatestCliVersion()
 
@@ -177,11 +184,12 @@ def isCliLatest():
         return True
 
     if remoteVer == localVer:
-        log(INFO, 'wakatime-cli is up to date.')
+        log(INFO, "wakatime-cli is up to date.")
         return True
 
-    log(INFO, 'Found an updated wakatime-cli %s' % remoteVer)
+    log(INFO, "Found an updated wakatime-cli %s" % remoteVer)
     return False
+
 
 def getLatestCliVersion():
     global LATEST_CLI_VERSION
@@ -193,34 +201,38 @@ def getLatestCliVersion():
     try:
         configs = parseConfigFile(INTERNAL_CONFIG_FILE)
         if configs:
-            if configs.has_option('internal', 'cli_version'):
-                last_version = configs.get('internal', 'cli_version')
-            if last_version and configs.has_option('internal', 'cli_version_last_modified'):
-                last_modified = configs.get('internal', 'cli_version_last_modified')
+            if configs.has_option("internal", "cli_version"):
+                last_version = configs.get("internal", "cli_version")
+            if last_version and configs.has_option(
+                "internal", "cli_version_last_modified"
+            ):
+                last_modified = configs.get("internal", "cli_version_last_modified")
     except:
         log(DEBUG, traceback.format_exc())
 
     try:
-        headers, contents, code = request(GITHUB_RELEASES_STABLE_URL, last_modified=last_modified)
+        headers, contents, code = request(
+            GITHUB_RELEASES_STABLE_URL, last_modified=last_modified
+        )
 
-        log(DEBUG, 'GitHub API Response {0}'.format(code))
+        log(DEBUG, "GitHub API Response {0}".format(code))
 
         if code == 304:
             LATEST_CLI_VERSION = last_version
             return last_version
 
-        data = json.loads(contents.decode('utf-8'))
+        data = json.loads(contents.decode("utf-8"))
 
-        ver = data['tag_name']
-        log(DEBUG, 'Latest wakatime-cli version from GitHub: {0}'.format(ver))
+        ver = data["tag_name"]
+        log(DEBUG, "Latest wakatime-cli version from GitHub: {0}".format(ver))
 
         if configs:
-            last_modified = headers.get('Last-Modified')
-            if not configs.has_section('internal'):
-                configs.add_section('internal')
-            configs.set('internal', 'cli_version', ver)
-            configs.set('internal', 'cli_version_last_modified', last_modified)
-            with open(INTERNAL_CONFIG_FILE, 'w', encoding='utf-8') as fh:
+            last_modified = headers.get("Last-Modified")
+            if not configs.has_section("internal"):
+                configs.add_section("internal")
+            configs.set("internal", "cli_version", ver)
+            configs.set("internal", "cli_version_last_modified", last_modified)
+            with open(INTERNAL_CONFIG_FILE, "w", encoding="utf-8") as fh:
                 configs.write(fh)
 
         LATEST_CLI_VERSION = ver
@@ -229,71 +241,79 @@ def getLatestCliVersion():
         log(DEBUG, traceback.format_exc())
         return None
 
+
 def extractVersion(text):
     pattern = re.compile(r"([0-9]+\.[0-9]+\.[0-9]+)")
     match = pattern.search(text)
     if match:
-        return 'v{ver}'.format(ver=match.group(1))
+        return "v{ver}".format(ver=match.group(1))
     return None
+
 
 def cliDownloadUrl():
     osname = platform.system().lower()
     arch = architecture()
 
     validCombinations = [
-      'darwin-amd64',
-      'darwin-arm64',
-      'freebsd-386',
-      'freebsd-amd64',
-      'freebsd-arm',
-      'linux-386',
-      'linux-amd64',
-      'linux-arm',
-      'linux-arm64',
-      'netbsd-386',
-      'netbsd-amd64',
-      'netbsd-arm',
-      'openbsd-386',
-      'openbsd-amd64',
-      'openbsd-arm',
-      'openbsd-arm64',
-      'windows-386',
-      'windows-amd64',
-      'windows-arm64',
+        "darwin-amd64",
+        "darwin-arm64",
+        "freebsd-386",
+        "freebsd-amd64",
+        "freebsd-arm",
+        "linux-386",
+        "linux-amd64",
+        "linux-arm",
+        "linux-arm64",
+        "netbsd-386",
+        "netbsd-amd64",
+        "netbsd-arm",
+        "openbsd-386",
+        "openbsd-amd64",
+        "openbsd-arm",
+        "openbsd-arm64",
+        "windows-386",
+        "windows-amd64",
+        "windows-arm64",
     ]
-    check = '{osname}-{arch}'.format(osname=osname, arch=arch)
+    check = "{osname}-{arch}".format(osname=osname, arch=arch)
     if check not in validCombinations:
         reportMissingPlatformSupport(osname, arch)
 
     version = getLatestCliVersion()
 
-    return '{prefix}/{version}/wakatime-cli-{osname}-{arch}.zip'.format(
+    return "{prefix}/{version}/wakatime-cli-{osname}-{arch}.zip".format(
         prefix=GITHUB_DOWNLOAD_PREFIX,
         version=version,
         osname=osname,
         arch=arch,
     )
 
+
 def reportMissingPlatformSupport(osname, arch):
-    url = 'https://api.wakatime.com/api/v1/cli-missing?osname={osname}&architecture={arch}&plugin=sublime'.format(
+    url = "https://api.wakatime.com/api/v1/cli-missing?osname={osname}&architecture={arch}&plugin=sublime".format(
         osname=osname,
         arch=arch,
     )
     request(url)
 
+
 def request(url, last_modified=None):
-    proxy = False # TODO: Support for Proxy (?)
+    proxy = False  # TODO: Support for Proxy (?)
     if proxy:
-        opener = urllib.request.build_opener(urllib.request.ProxyHandler({
-            'http': proxy,
-            'https': proxy,
-        }))
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler(
+                {
+                    "http": proxy,
+                    "https": proxy,
+                }
+            )
+        )
     else:
         opener = urllib.request.build_opener()
 
-    headers = [('User-Agent', 'github.com/wakatime/sublime-wakatime')]
+    headers = [("User-Agent", "github.com/wakatime/sublime-wakatime")]
     if last_modified:
-        headers.append(('If-Modified-Since', last_modified))
+        headers.append(("If-Modified-Since", last_modified))
 
     opener.addheaders = headers
 
@@ -311,16 +331,21 @@ def request(url, last_modified=None):
     except IOError:
         raise
 
+
 def download(url, filePath):
-    proxy = False # TODO: Support for Proxy (?)
+    proxy = False  # TODO: Support for Proxy (?)
     if proxy:
-        opener = urllib.request.build_opener(urllib.request.ProxyHandler({
-            'http': proxy,
-            'https': proxy,
-        }))
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler(
+                {
+                    "http": proxy,
+                    "https": proxy,
+                }
+            )
+        )
     else:
         opener = urllib.request.build_opener()
-    opener.addheaders = [('User-Agent', 'github.com/wakatime/sublime-wakatime')]
+    opener.addheaders = [("User-Agent", "github.com/wakatime/sublime-wakatime")]
 
     urllib.request.install_opener(opener)
 
@@ -328,5 +353,6 @@ def download(url, filePath):
         urllib.request.urlretrieve(url, filePath)
     except IOError:
         raise
+
 
 # Removed force downloader. Addon still checks on each startup.


### PR DESCRIPTION
This is updated to fix the current issues with using legacy Python CLI.
Most code is from the sublime editor plugin which is also in Python.

- Removed force download client button
- Fetches CLI executable based on os and architecture